### PR TITLE
drop numpy pin

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,6 +1,7 @@
 name: continuous integration tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
     - python
   run:
     - python
-    - numpy=1.23
+    - numpy
     - scipy
     - optlang
     - cobra>=0.26.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["numpy==1.23.*", "scipy", "cobra>=0.29", "optlang", "efmtool_link>=0.0.6", "sympy>=1.12", "swiglpk"]
+dependencies = ["numpy", "scipy", "cobra>=0.29", "optlang", "efmtool_link>=0.0.6", "sympy>=1.12", "swiglpk"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
The pin was probably introduced because of straindesign's problems with scipy>=1.13. Should be obsolete.